### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/_activities/2017-11-23-DS-SICSA.md
+++ b/_activities/2017-11-23-DS-SICSA.md
@@ -16,7 +16,7 @@ Then, all the participants had to rank the topics with regards to how similar th
 The Well Sorted website grouped the topics into groups using these rankings.
 During the event we had two sets of meetings: the first one about analysing the topics in a group in more depth and identifying three top research challenges, and the second one about brainstorming about the impact of the previously identified challenges.
 We had very short presentations after each meeting from all groups which allowed all the participants to be aware of what was discussed in the other groups.
-Finally, a [technical report](http://doi.org/10.13140/RG.2.2.29223.04004) was published to capture all of this.
+Finally, a [technical report](https://doi.org/10.13140/RG.2.2.29223.04004) was published to capture all of this.
 
 <!-- Also here: [technical report](/files/fulltext/2017/Research_Challenges_in_Data_Science_23_11_2017.pdf) -->
 

--- a/_includes/bib.html
+++ b/_includes/bib.html
@@ -3,7 +3,7 @@
 <p></p><hr><dt>2017</dt>
 <dd><b>Automatically improving constraint models in Savile Row</b><br>Peter Nightingale, <u>Özgür Akgün</u>, Ian Gent, Christopher Jefferson, Ian Miguel, Patrick Spracklen
 <br>Artificial Intelligence, Elsevier
-<br><a href="https://dx.doi.org/10.1016/j.artint.2017.07.001">DOI: 10.1016/j.artint.2017.07.001</a></dd>
+<br><a href="https://doi.org/10.1016/j.artint.2017.07.001">DOI: 10.1016/j.artint.2017.07.001</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Learning From Past Links: Understanding the Limits of Linkage Quality</b><br><u>Özgür Akgün</u>, Alan Dearle, Eilidh Garrett, Graham Kirby
@@ -32,42 +32,42 @@
 <p></p><hr><dt>2016</dt>
 <dd><b>Cloud Benchmarking for Maximising Performance of Scientific Applications</b><br>Blesson Varghese, <u>Özgür Akgün</u>, Ian Miguel, Long Thai, Adam Barker
 <br>IEEE Transactions on Cloud Computing, IEEE
-<br><a href="https://dx.doi.org/10.1109/TCC.2016.2603476">DOI: 10.1109/TCC.2016.2603476</a></dd>
+<br><a href="https://doi.org/10.1109/TCC.2016.2603476">DOI: 10.1109/TCC.2016.2603476</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Exploiting Short Supports for Improved Encoding of Arbitrary Constraints into SAT</b><br><u>Özgür Akgün</u>, Ian Gent, Chris Jefferson, Ian Miguel, Peter Nightingale
 <br>Principles and Practice of Constraint Programming, Springer
-<br><a href="https://dx.doi.org/10.1007/978-3-319-44953-1_1">DOI: 10.1007/978-3-319-44953-1_1</a></dd>
+<br><a href="https://doi.org/10.1007/978-3-319-44953-1_1">DOI: 10.1007/978-3-319-44953-1_1</a></dd>
 
 <p></p><hr><dt>2015</dt>
 <dd><b>Cloud-based e-Infrastructure for scheduling astronomical observations</b><br>James Wetter, <u>Özgür Akgün</u>, Adam Barker, Martin Dominik, Ian Miguel, Blesson Varghese
 <br>2015 IEEE 11th International Conference on e-Science (e-Science) (2015), IEEE Computer Society
-<br><a href="https://dx.doi.org/10.1109/eScience.2015.54">DOI: 10.1109/eScience.2015.54</a></dd>
+<br><a href="https://doi.org/10.1109/eScience.2015.54">DOI: 10.1109/eScience.2015.54</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Automatically Generating Streamlined Constraint Models with Essence and Conjure</b><br>James Wetter, <u>Özgür Akgün</u>, Ian Miguel
 <br>Principles and Practice of Constraint Programming, Springer
-<br><a href="https://dx.doi.org/10.1007/978-3-319-23219-5_34">DOI: 10.1007/978-3-319-23219-5_34</a></dd>
+<br><a href="https://doi.org/10.1007/978-3-319-23219-5_34">DOI: 10.1007/978-3-319-23219-5_34</a></dd>
 
 <p></p><hr><dt>2014</dt>
 <dd><b>Cloud Benchmarking for Performance</b><br>Blesson Varghese, <u>Özgür Akgün</u>, Ian Miguel, Long Thai, Adam Barker
 <br>6th IEEE International Conference on Cloud Computing Technology and Science (CloudCom 2014), IEEE
-<br><a href="https://dx.doi.org/10.1109/CloudCom.2014.28">DOI: 10.1109/CloudCom.2014.28</a></dd>
+<br><a href="https://doi.org/10.1109/CloudCom.2014.28">DOI: 10.1109/CloudCom.2014.28</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Optimal Deployment of Geographically Distributed Workflow Engines on the Cloud</b><br>Long Thai, Adam Barker, Blesson Varghese, <u>Özgür Akgün</u>, Ian Miguel
 <br>6th IEEE International Conference on Cloud Computing Technology and Science (CloudCom 2014), IEEE
-<br><a href="https://dx.doi.org/10.1109/CloudCom.2014.30">DOI: 10.1109/CloudCom.2014.30</a></dd>
+<br><a href="https://doi.org/10.1109/CloudCom.2014.30">DOI: 10.1109/CloudCom.2014.30</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Automatically Improving Constraint Models in Savile Row through Associative-Commutative Common Subexpression Elimination</b><br>Peter Nightingale, <u>Özgür Akgün</u>, Ian Gent, Christopher Jefferson, Ian Miguel
 <br>Principles and Practice of Constraint Programming, Springer
-<br><a href="https://dx.doi.org/10.1007/978-3-319-10428-7_43">DOI: 10.1007/978-3-319-10428-7_43</a></dd>
+<br><a href="https://doi.org/10.1007/978-3-319-10428-7_43">DOI: 10.1007/978-3-319-10428-7_43</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Breaking Conditional Symmetry in Automated Constraint Modelling with Conjure</b><br><u>Özgür Akgün</u>, Ian Gent, Chris Jefferson, Ian Miguel, Peter Nightingale
 <br>ECAI 2014, IOS Press
-<br><a href="https://dx.doi.org/10.3233/978-1-61499-419-0-3">DOI: 10.3233/978-1-61499-419-0-3</a></dd>
+<br><a href="https://doi.org/10.3233/978-1-61499-419-0-3">DOI: 10.3233/978-1-61499-419-0-3</a></dd>
 
 <p></p><dt></dt>
 <dd><b>Extensible Automated Constraint Modelling via Refinement of Abstract Problem Specifications</b><br><u>Özgür Akgün</u>
@@ -85,7 +85,7 @@
 <p></p><dt></dt>
 <dd><b>Automated Symmetry Breaking and Model Selection in Conjure</b><br><u>Özgür Akgün</u>, Alan M Frisch, Ian Gent, Bilal Syed Hussain, Chris Jefferson, Lars Kotthoff, Ian Miguel, Peter Nightingale
 <br>CP 2013 - Principles and Practice of Constraint Programming, 19th International Conference
-<br><a href="https://dx.doi.org/10.1007/978-3-642-40627-0_11">DOI: 10.1007/978-3-642-40627-0_11</a></dd>
+<br><a href="https://doi.org/10.1007/978-3-642-40627-0_11">DOI: 10.1007/978-3-642-40627-0_11</a></dd>
 
 <p></p><hr><dt>2011</dt>
 <dd><b>Extensible Automated Constraint Modelling</b><br><u>Özgür Akgün</u>, Ian Miguel, Chris Jefferson, Alan M. Frisch, Brahim Hnich

--- a/bib/render.rb
+++ b/bib/render.rb
@@ -67,7 +67,7 @@ for bib in bibs do
 
   if bib.key?('DOI') then
     print "\n<br>"
-    print "<a href=\"https://dx.doi.org/#{bib['DOI']}\">DOI: #{bib['DOI']}</a>"
+    print "<a href=\"https://doi.org/#{bib['DOI']}\">DOI: #{bib['DOI']}</a>"
   elsif bib.key?('URL') then
     print "\n<br>"
     print "<a href=\"#{bib['URL']}\">URL: #{bib['URL']}</a>"


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!